### PR TITLE
adding quotes around curl commands with &s

### DIFF
--- a/_episodes/02-first-apis.md
+++ b/_episodes/02-first-apis.md
@@ -236,14 +236,20 @@ an endpoint.
 
 Many APIs make this distinction more clear, by accepting arguments in a _query
 string_. This is a sequence of `name=value` pairs, separated from each other by
-`&`s, and separated from the endpoint by a `?`.
+`&`s, and separated from the endpoint by a `?`. 
+
+~~~
+## Using quotes with Curl
+When we put an & into a web address for Curl we need to put it inside quotes. If we don't then our shell will interpret them as meaning we should run the preceeding command in the background instead of passing it as a parameter to curl. This will effectively truncate the address to everything up to the first &.
+~~~
+{: .callout}
 
 We have already seen one example of this&mdash;we used it to provide our API key
 to NASA's APOD endpoint. The APOD endpoint also accepts other parameters, for
 example, to select the date or dates for which the picture is returned.
 
 ~~~
-$ curl -i https://api.nasa.gov/planetary/apod?date=2005-04-01&api_key=ejgThfasPCRf4kTd39ar55Aqhxv8cwKBdVOyZ9Rr
+$ curl -i "https://api.nasa.gov/planetary/apod?date=2005-04-01&api_key=ejgThfasPCRf4kTd39ar55Aqhxv8cwKBdVOyZ9Rr"
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
Running without quotes causes bash (and possibly other shells) to attempt to background the job and truncates the URL at the point of the first &. 

I've fixed this for what I think is the only instance of it and added a callout explaining why its done.