### PR TITLE
Removing List comprehensions

### DIFF
--- a/_episodes/04-requests.md
+++ b/_episodes/04-requests.md
@@ -350,11 +350,13 @@ data["SiteRep"]["Wx"]
 > > e.g. Cardiff:
 > >
 > > ~~~
-> > [ site for site in sitelist if site["name"] == "Cardiff"] 
+> > for site in sitelist:
+> >     if site["name"] == "Cardiff":
+> >         print(site['id'])
 > > ~~~
 > > {: .language-python}
 > >
-> > One of the location ID is `350758`,
+> > Cardiff has two locations, one of the location's ID is `350758`,
 > > so we can use it:
 > >
 > > ~~~

--- a/_episodes/05-scraping.md
+++ b/_episodes/05-scraping.md
@@ -328,8 +328,14 @@ from the text content of `td1`:
 
 ~~~
 td1_text_split = td1.text.split("Instructors:")
-instructors = [ name.strip() for name in td1_text_split[1].split(",")]
-instructors
+
+# create a blank list to populate with the instructor names
+instructors = []
+
+for name in td1_text_split[1].split(","):
+    instructors.append(name.strip())
+
+print(instructors)
 ~~~
 {: .language-python}
 
@@ -388,7 +394,9 @@ instructors
 > >     instructors_string = people[0]
 > >     # we ignore helpers, might not be present
 > >     # helpers_string = people[1] 
-> >     instructors = [ n.strip() for n in instructors_string.split(",")]
+> >     instructors = []
+> >     for n in instructors_string.split(","):
+> >         instructors.append(n.strip())
 > >     date = td2.text.strip()
 > >
 > >     return dict(
@@ -398,7 +406,9 @@ instructors
 > >        date = date
 > >     ) 
 > >
-> > workshops = [ process_row(row) for row in rows ]
+> > workshops = []
+> > for row in rows:
+> >     workshops.append(process_row(row))
 > > ~~~
 > > {: .language-python}
 > {: .solution}


### PR DESCRIPTION
We haven't explained what list comprehensions are, they aren't covered in the Carpentries Python courses so we can't really assume our learners know about them. 

We can either add a section explaining how they work or we can convert them to standard loops which append to lists. This pull request does the latter. 